### PR TITLE
Add new endpoint /boards

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 module.exports = function appConfig(config) {
     return {
         key: config.getString('SERVICE_BASE_API_KEY'),
-        firstParamUI: config.getString('FIRST_PARAM_UI'),
+        firstParamUI: config.getNullableString('FIRST_PARAM_UI'),
         assetCache: {
             host: config.getString('ASSET_CACHE_HOST'),
             port: config.getInt('ASSET_CACHE_PORT'),

--- a/src/connectors/mock.js
+++ b/src/connectors/mock.js
@@ -1,0 +1,35 @@
+const ApiError = require('@prodigy/api').Error;
+
+function MockConnector() {
+}
+
+function Board(id, name, enabledFlag, modifiedDate) {
+    this.id = id;
+    this.name = name;
+    this.enabledFlag = enabledFlag;
+    this.modifiedDate = modifiedDate;
+}
+
+MockConnector.getBoard = (id, name, container) => {
+    const successIds = [1, 5, 345];
+    const rows = [];
+    const logger = container.logger;
+    // const enabledFlag = container.config.getString('FIRST_PARAM_U');
+    // console.log(enabledFlag);
+
+    return new Promise((resolve, reject) => {
+        if (!successIds.includes(id)) {
+            logger.error('get_user_data', `MockError: User not found for id ${id}`);
+            reject(new ApiError.Generic());
+            return;
+        }
+
+        if (successIds.includes(id)) {
+            rows.push(new Board(id, name || 'Default', 'on', Date.now()));
+        }
+
+        resolve(rows);
+    });
+};
+
+module.exports = MockConnector;

--- a/src/connectors/mock.js
+++ b/src/connectors/mock.js
@@ -10,12 +10,11 @@ function Board(id, name, enabledFlag, modifiedDate) {
     this.modifiedDate = modifiedDate;
 }
 
-MockConnector.getBoard = (id, name, container) => {
+MockConnector.getBoard = (id, name, services) => {
     const successIds = [1, 5, 345];
     const rows = [];
-    const logger = container.logger;
-    // const enabledFlag = container.config.getString('FIRST_PARAM_U');
-    // console.log(enabledFlag);
+    const { logger, config } = services;
+    const enabledFlag = config.get('playground-base-api.firstParamUI') || 'default-on';
 
     return new Promise((resolve, reject) => {
         if (!successIds.includes(id)) {
@@ -25,7 +24,7 @@ MockConnector.getBoard = (id, name, container) => {
         }
 
         if (successIds.includes(id)) {
-            rows.push(new Board(id, name || 'Default', 'on', Date.now()));
+            rows.push(new Board(id, name || 'Default', enabledFlag, Date.now()));
         }
 
         resolve(rows);

--- a/src/routes/boards.js
+++ b/src/routes/boards.js
@@ -1,0 +1,48 @@
+const Boards = require('../services/boards');
+
+/**
+ * @api {get} /playground-base-api/board/:id Get board data
+ * @apiName getBoard
+ * @apiGroup payground-base-api
+ * @apiDescription Get data for a given board
+ *
+ * @apiParam  {Number} boardID Eg. 23423
+ * @apiParam  {String}  name Eg. 'Dashboard'
+ *
+ * @apiSuccess (200) {Number} boardID
+ * @apiSuccess (200) {String} name
+ * @apiSuccess (200) {DateTime} modifiedDate
+ */
+
+exports.getBoard = {
+    name: 'getBoard',
+    method: 'get',
+    endpoint: '/playground-base-api/board/:id',
+    desc: 'sample get route for retrieving board data',
+    session_auth: false,
+    application_auth: false,
+    version: 'v1',
+    inputs: {
+        id: {
+            required: true,
+            formatter: value => parseInt(value, 10),
+            validate: value => value > 0,
+        },
+        name: {
+            required: false,
+        },
+    },
+    // TO DO: is container = services or the entire api obj
+    // check prodigy-api repo
+    run: (container, data, next) => {
+        Boards.getBoard(data, container)
+            .then((result) => {
+                next(200, result);
+            })
+            .catch((error) => {
+                next(error.statusCode || 500, error);
+                return;
+            });
+    },
+};
+

--- a/src/services/boards.js
+++ b/src/services/boards.js
@@ -1,0 +1,7 @@
+const MockConnector = require('../connectors/mock');
+
+function Boards() {}
+
+Boards.getBoard = ({ id, name }, container) => MockConnector.getBoard(id, name, container);
+
+module.exports = Boards;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* enable and access a new api endpoint /boards/:1

## How Has This Been Tested?
local

## How Should This Be Manually Tested?
http://127.0.0.1:3000/playground-base-api/board/1

## Screenshots (if appropriate):

## Types of changes
- [x ] New feature (non-breaking change which adds functionality)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Because this PR will change the database schema, I have submitted a ServiceDesk ticket ([link](https://prodigygame.atlassian.net/servicedesk/customer/portal/1/group/9/create/42)) to notify the InfoSec Squad.
